### PR TITLE
Refactor for cleaner architecture

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4296,6 +4296,7 @@ dependencies = [
 name = "urxiv"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "chrono",
  "dirs 5.0.1",
  "serde",
@@ -4304,6 +4305,7 @@ dependencies = [
  "tauri-build",
  "tauri-plugin-dialog",
  "tauri-plugin-opener",
+ "thiserror 1.0.69",
  "walkdir",
 ]
 

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -26,6 +26,8 @@ chrono = { version = "0.4", features = ["serde"] }
 dirs = "5.0"
 walkdir = "2.3"
 tauri-plugin-dialog = "2"
+thiserror = "1"
+anyhow = "1"
 
 [features]
 custom-protocol = ["tauri/custom-protocol"]

--- a/src-tauri/src/commands/blocks.rs
+++ b/src-tauri/src/commands/blocks.rs
@@ -1,13 +1,11 @@
 use chrono::Utc;
 use serde_json::Value;
-use std::fs;
 use std::sync::atomic::Ordering;
 use tauri::State;
 
 use crate::error::{AppError, Result};
 use crate::models::{AppState, Block, BlockKind};
-use crate::repository::{BlockRepository, FileBlockRepository};
-use crate::storage;
+use crate::repository::BlockRepository;
 
 #[tauri::command]
 pub fn get_all_blocks(state: State<AppState>) -> Result<Vec<Block>> {
@@ -37,11 +35,7 @@ pub fn get_all_channels(state: State<AppState>) -> Result<Vec<Block>> {
 }
 
 #[tauri::command]
-pub fn create_channel(
-    title: String,
-    description: String,
-    state: State<AppState>,
-) -> Result<Block> {
+pub fn create_channel(title: String, description: String, state: State<AppState>) -> Result<Block> {
     let mut repo_lock = state.repository.lock().unwrap();
     let repo = repo_lock.as_mut().ok_or(AppError::NoWorkspaceSelected)?;
 
@@ -61,10 +55,7 @@ pub fn get_block(block_id: u64, state: State<AppState>) -> Result<Block> {
 }
 
 #[tauri::command]
-pub fn get_blocks_in_channel(
-    channel_id: u64,
-    state: State<AppState>,
-) -> Result<Vec<Block>> {
+pub fn get_blocks_in_channel(channel_id: u64, state: State<AppState>) -> Result<Vec<Block>> {
     let repo_lock = state.repository.lock().unwrap();
     let repo = repo_lock.as_ref().ok_or(AppError::NoWorkspaceSelected)?;
 
@@ -86,11 +77,7 @@ pub fn get_blocks_in_channel(
 }
 
 #[tauri::command]
-pub fn connect_blocks(
-    source_id: u64,
-    target_id: u64,
-    state: State<AppState>,
-) -> Result<()> {
+pub fn connect_blocks(source_id: u64, target_id: u64, state: State<AppState>) -> Result<()> {
     let mut repo_lock = state.repository.lock().unwrap();
     let repo = repo_lock.as_mut().ok_or(AppError::NoWorkspaceSelected)?;
 
@@ -108,11 +95,7 @@ pub fn connect_blocks(
 }
 
 #[tauri::command]
-pub fn disconnect_blocks(
-    source_id: u64,
-    target_id: u64,
-    state: State<AppState>,
-) -> Result<()> {
+pub fn disconnect_blocks(source_id: u64, target_id: u64, state: State<AppState>) -> Result<()> {
     let mut repo_lock = state.repository.lock().unwrap();
     let repo = repo_lock.as_mut().ok_or(AppError::NoWorkspaceSelected)?;
 

--- a/src-tauri/src/commands/blocks.rs
+++ b/src-tauri/src/commands/blocks.rs
@@ -1,37 +1,39 @@
 use chrono::Utc;
+use serde_json::Value;
 use std::fs;
 use std::sync::atomic::Ordering;
 use tauri::State;
 
-use crate::models::{AppState, Block};
+use crate::error::{AppError, Result};
+use crate::models::{AppState, Block, BlockKind};
+use crate::repository::{BlockRepository, FileBlockRepository};
 use crate::storage;
 
 #[tauri::command]
-pub fn get_all_blocks(state: State<AppState>) -> Result<Vec<Block>, String> {
-    let blocks_cache = state.blocks_cache.lock().unwrap();
-    Ok(blocks_cache.values().cloned().collect())
+pub fn get_all_blocks(state: State<AppState>) -> Result<Vec<Block>> {
+    if let Some(repo) = &*state.repository.lock().unwrap() {
+        repo.all()
+    } else {
+        Ok(Vec::new())
+    }
 }
 
 #[tauri::command]
-pub fn get_all_files(state: State<AppState>) -> Result<Vec<Block>, String> {
-    let blocks_cache = state.blocks_cache.lock().unwrap();
-    let files: Vec<Block> = blocks_cache
-        .values()
-        .filter(|block| block.block_type == "file")
-        .cloned()
-        .collect();
-    Ok(files)
+pub fn get_all_files(state: State<AppState>) -> Result<Vec<Block>> {
+    if let Some(repo) = &*state.repository.lock().unwrap() {
+        repo.all_files()
+    } else {
+        Ok(Vec::new())
+    }
 }
 
 #[tauri::command]
-pub fn get_all_channels(state: State<AppState>) -> Result<Vec<Block>, String> {
-    let blocks_cache = state.blocks_cache.lock().unwrap();
-    let channels: Vec<Block> = blocks_cache
-        .values()
-        .filter(|block| block.block_type == "channel")
-        .cloned()
-        .collect();
-    Ok(channels)
+pub fn get_all_channels(state: State<AppState>) -> Result<Vec<Block>> {
+    if let Some(repo) = &*state.repository.lock().unwrap() {
+        repo.all_channels()
+    } else {
+        Ok(Vec::new())
+    }
 }
 
 #[tauri::command]
@@ -39,66 +41,43 @@ pub fn create_channel(
     title: String,
     description: String,
     state: State<AppState>,
-) -> Result<Block, String> {
-    let data_dir = match state.data_dir.lock().unwrap().clone() {
-        Some(dir) => dir,
-        None => return Err("No workspace selected".to_string()),
-    };
+) -> Result<Block> {
+    let mut repo_lock = state.repository.lock().unwrap();
+    let repo = repo_lock.as_mut().ok_or(AppError::NoWorkspaceSelected)?;
 
     let block_id = state.next_id.fetch_add(1, Ordering::SeqCst);
-    let now = Utc::now();
+    let block = Block::new_channel(block_id, title, description);
 
-    let content = serde_json::json!({
-        "title": title,
-        "description": description
-    });
-
-    let block = Block {
-        id: block_id,
-        created_at: now,
-        updated_at: now,
-        block_type: "channel".to_string(),
-        content,
-        connections: Vec::new(),
-    };
-
-    let mut blocks_cache = state.blocks_cache.lock().unwrap();
-    storage::save_block(&block, &data_dir, &mut blocks_cache)?;
+    repo.save(&block)?;
 
     Ok(block)
 }
 
 #[tauri::command]
-pub fn get_block(block_id: u64, state: State<AppState>) -> Result<Block, String> {
-    let blocks_cache = state.blocks_cache.lock().unwrap();
-
-    if let Some(block) = blocks_cache.get(&block_id) {
-        Ok(block.clone())
-    } else {
-        Err(format!("Block {} not found", block_id))
-    }
+pub fn get_block(block_id: u64, state: State<AppState>) -> Result<Block> {
+    let repo_lock = state.repository.lock().unwrap();
+    let repo = repo_lock.as_ref().ok_or(AppError::NoWorkspaceSelected)?;
+    repo.get(block_id)
 }
 
 #[tauri::command]
 pub fn get_blocks_in_channel(
     channel_id: u64,
     state: State<AppState>,
-) -> Result<Vec<Block>, String> {
-    let blocks_cache = state.blocks_cache.lock().unwrap();
+) -> Result<Vec<Block>> {
+    let repo_lock = state.repository.lock().unwrap();
+    let repo = repo_lock.as_ref().ok_or(AppError::NoWorkspaceSelected)?;
 
-    let channel = match blocks_cache.get(&channel_id) {
-        Some(block) => block,
-        None => return Err(format!("Channel {} not found", channel_id)),
-    };
+    let channel = repo.get(channel_id)?;
 
-    if channel.block_type != "channel" {
-        return Err(format!("Block {} is not a channel", channel_id));
+    if !matches!(channel.kind, BlockKind::Channel(_)) {
+        return Err(AppError::NotAChannel(channel_id));
     }
 
     let mut blocks = Vec::new();
     for &block_id in &channel.connections {
-        if let Some(block) = blocks_cache.get(&block_id) {
-            blocks.push(block.clone());
+        if let Ok(block) = repo.get(block_id) {
+            blocks.push(block);
         }
     }
 
@@ -111,30 +90,18 @@ pub fn connect_blocks(
     source_id: u64,
     target_id: u64,
     state: State<AppState>,
-) -> Result<(), String> {
-    let data_dir = match state.data_dir.lock().unwrap().clone() {
-        Some(dir) => dir,
-        None => return Err("No workspace selected".to_string()),
-    };
-
-    let mut blocks_cache = state.blocks_cache.lock().unwrap();
+) -> Result<()> {
+    let mut repo_lock = state.repository.lock().unwrap();
+    let repo = repo_lock.as_mut().ok_or(AppError::NoWorkspaceSelected)?;
 
     // Verify both blocks exist
-    if !blocks_cache.contains_key(&source_id) {
-        return Err(format!("Source block {} not found", source_id));
-    }
-
-    if !blocks_cache.contains_key(&target_id) {
-        return Err(format!("Target block {} not found", target_id));
-    }
-
-    // Update source block's connections
-    let mut source_block = blocks_cache.get(&source_id).unwrap().clone();
+    let mut source_block = repo.get(source_id)?;
+    repo.get(target_id)?;
 
     if !source_block.connections.contains(&target_id) {
         source_block.connections.push(target_id);
         source_block.updated_at = Utc::now();
-        storage::save_block(&source_block, &data_dir, &mut blocks_cache)?;
+        repo.save(&source_block)?;
     }
 
     Ok(())
@@ -145,21 +112,13 @@ pub fn disconnect_blocks(
     source_id: u64,
     target_id: u64,
     state: State<AppState>,
-) -> Result<(), String> {
-    let data_dir = match state.data_dir.lock().unwrap().clone() {
-        Some(dir) => dir,
-        None => return Err("No workspace selected".to_string()),
-    };
-
-    let mut blocks_cache = state.blocks_cache.lock().unwrap();
+) -> Result<()> {
+    let mut repo_lock = state.repository.lock().unwrap();
+    let repo = repo_lock.as_mut().ok_or(AppError::NoWorkspaceSelected)?;
 
     // Verify both blocks exist
-    if !blocks_cache.contains_key(&source_id) {
-        return Err(format!("Source block {} not found", source_id));
-    }
-
-    // Update source block's connections
-    let mut source_block = blocks_cache.get(&source_id).unwrap().clone();
+    let mut source_block = repo.get(source_id)?;
+    repo.get(target_id)?;
 
     if let Some(pos) = source_block
         .connections
@@ -168,33 +127,26 @@ pub fn disconnect_blocks(
     {
         source_block.connections.remove(pos);
         source_block.updated_at = Utc::now();
-        storage::save_block(&source_block, &data_dir, &mut blocks_cache)?;
+        repo.save(&source_block)?;
     }
 
     Ok(())
 }
 
 #[tauri::command]
-pub fn delete_block(block_id: u64, state: State<AppState>) -> Result<(), String> {
-    let data_dir = match state.data_dir.lock().unwrap().clone() {
-        Some(dir) => dir,
-        None => return Err("No workspace selected".to_string()),
-    };
-
-    let mut blocks_cache = state.blocks_cache.lock().unwrap();
+pub fn delete_block(block_id: u64, state: State<AppState>) -> Result<()> {
+    let mut repo_lock = state.repository.lock().unwrap();
+    let repo = repo_lock.as_mut().ok_or(AppError::NoWorkspaceSelected)?;
 
     // Verify the block exists
-    if !blocks_cache.contains_key(&block_id) {
-        return Err(format!("Block {} not found", block_id));
-    }
+    repo.get(block_id)?;
 
     // Remove this block from all connections in other blocks
-    for other_id in blocks_cache.keys().cloned().collect::<Vec<u64>>() {
-        if other_id == block_id {
+    let all_blocks = repo.all()?;
+    for mut other_block in all_blocks {
+        if other_block.id == block_id {
             continue;
         }
-
-        let mut other_block = blocks_cache.get(&other_id).unwrap().clone();
 
         if let Some(pos) = other_block
             .connections
@@ -203,47 +155,30 @@ pub fn delete_block(block_id: u64, state: State<AppState>) -> Result<(), String>
         {
             other_block.connections.remove(pos);
             other_block.updated_at = Utc::now();
-            storage::save_block(&other_block, &data_dir, &mut blocks_cache)?;
+            repo.save(&other_block)?;
         }
     }
 
-    // Delete the block file
-    let block_path = data_dir.join("blocks").join(format!("{}.json", block_id));
-    if block_path.exists() {
-        fs::remove_file(block_path).map_err(|e| e.to_string())?;
-    }
-
-    // Remove from cache
-    blocks_cache.remove(&block_id);
-
-    Ok(())
+    repo.delete(block_id)
 }
 
 #[tauri::command]
 pub fn update_block_content(
     block_id: u64,
-    new_content: serde_json::Value,
+    new_content: Value,
     state: State<AppState>,
-) -> Result<Block, String> {
-    let data_dir = match state.data_dir.lock().unwrap().clone() {
-        Some(dir) => dir,
-        None => return Err("No workspace selected".to_string()),
-    };
-
-    let mut blocks_cache = state.blocks_cache.lock().unwrap();
+) -> Result<Block> {
+    let mut repo_lock = state.repository.lock().unwrap();
+    let repo = repo_lock.as_mut().ok_or(AppError::NoWorkspaceSelected)?;
 
     // Verify the block exists
-    if !blocks_cache.contains_key(&block_id) {
-        return Err(format!("Block {} not found", block_id));
-    }
+    let mut block = repo.get(block_id)?;
 
-    let mut block = blocks_cache.get(&block_id).unwrap().clone();
-
-    // Update block content
-    block.content = new_content;
+    let new_kind: BlockKind = serde_json::from_value(new_content)?;
+    block.kind = new_kind;
     block.updated_at = Utc::now();
 
-    storage::save_block(&block, &data_dir, &mut blocks_cache)?;
+    repo.save(&block)?;
 
     Ok(block)
 }

--- a/src-tauri/src/commands/workspace.rs
+++ b/src-tauri/src/commands/workspace.rs
@@ -1,20 +1,21 @@
-use chrono::Utc;
 use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::atomic::Ordering;
 use tauri::State;
 use walkdir::WalkDir;
 
+use crate::error::{AppError, Result};
 use crate::models::{AppState, Block};
+use crate::repository::{BlockRepository, FileBlockRepository};
 use crate::storage;
 
 #[tauri::command]
-pub fn select_workspace(path: String, state: State<AppState>) -> Result<(), String> {
+pub fn select_workspace(path: String, state: State<AppState>) -> Result<()> {
     let path = PathBuf::from(path);
 
     // Create data directory inside the workspace
     let data_dir = path.join(".urxiv");
-    storage::initialize_dirs(&data_dir).map_err(|e| e.to_string())?;
+    storage::initialize_dirs(&data_dir)?;
 
     // Set workspace and data directory
     *state.workspace_dir.lock().unwrap() = Some(path.clone());
@@ -24,40 +25,42 @@ pub fn select_workspace(path: String, state: State<AppState>) -> Result<(), Stri
     let blocks_dir = data_dir.join("blocks");
     let highest_id = storage::find_highest_block_id(&blocks_dir);
     let blocks_cache = storage::load_blocks_cache(&blocks_dir);
+    let mut repository = FileBlockRepository::new(data_dir.clone(), blocks_cache);
 
     // Update state
-    *state.blocks_cache.lock().unwrap() = blocks_cache;
+    let all_blocks = repository.all()?;
+    *state.blocks_cache.lock().unwrap() =
+        all_blocks.iter().cloned().map(|b| (b.id, b)).collect();
+    *state.repository.lock().unwrap() = Some(repository);
     state.next_id.store(highest_id + 1, Ordering::SeqCst);
 
     Ok(())
 }
 
 #[tauri::command]
-pub fn get_workspace_status(state: State<AppState>) -> Result<bool, String> {
+pub fn get_workspace_status(state: State<AppState>) -> Result<bool> {
     Ok(state.workspace_dir.lock().unwrap().is_some())
 }
 
 #[tauri::command]
-pub fn index_workspace_files(state: State<AppState>) -> Result<Vec<Block>, String> {
+pub fn index_workspace_files(state: State<AppState>) -> Result<Vec<Block>> {
     let workspace_dir = match state.workspace_dir.lock().unwrap().clone() {
         Some(dir) => dir,
-        None => return Err("No workspace selected".to_string()),
+        None => return Err(AppError::NoWorkspaceSelected),
     };
 
-    let data_dir = state.data_dir.lock().unwrap().clone().unwrap();
-    let mut blocks_cache = state.blocks_cache.lock().unwrap();
+    let mut repo_lock = state.repository.lock().unwrap();
+    let repo = repo_lock.as_mut().ok_or(AppError::NoWorkspaceSelected)?;
+
     let mut indexed_blocks = Vec::new();
 
     // Create a set of all existing file paths in our blocks
-    let existing_files: HashMap<String, u64> = blocks_cache
-        .values()
-        .filter(|block| block.block_type == "file")
-        .filter_map(|block| {
-            block
-                .content
-                .get("path")
-                .and_then(|p| p.as_str())
-                .map(|path| (path.to_string(), block.id))
+    let existing_files: HashMap<String, u64> = repo
+        .all_files()?
+        .into_iter()
+        .filter_map(|b| match b.kind {
+            BlockKind::File(f) => Some((f.path, b.id)),
+            _ => None,
         })
         .collect();
 
@@ -87,8 +90,8 @@ pub fn index_workspace_files(state: State<AppState>) -> Result<Vec<Block>, Strin
             if existing_files.contains_key(&path_str) {
                 // Already indexed this file
                 if let Some(block_id) = existing_files.get(&path_str) {
-                    if let Some(block) = blocks_cache.get(block_id) {
-                        indexed_blocks.push(block.clone());
+                    if let Ok(block) = repo.get(*block_id) {
+                        indexed_blocks.push(block);
                     }
                 }
                 continue;
@@ -103,7 +106,6 @@ pub fn index_workspace_files(state: State<AppState>) -> Result<Vec<Block>, Strin
             }
 
             // Create a new block for this file
-            let now = Utc::now();
             let block_id = state.next_id.fetch_add(1, Ordering::SeqCst);
 
             // Extract filename
@@ -113,24 +115,16 @@ pub fn index_workspace_files(state: State<AppState>) -> Result<Vec<Block>, Strin
                 .unwrap_or("Unknown")
                 .to_string();
 
-            let content = serde_json::json!({
-                "path": path_str,
-                "filename": filename,
-                "file_type": file_type,
-                "full_path": path.to_string_lossy().to_string()
-            });
-
-            let block = Block {
-                id: block_id,
-                created_at: now,
-                updated_at: now,
-                block_type: "file".to_string(),
-                content,
-                connections: Vec::new(),
-            };
+            let block = Block::new_file(
+                block_id,
+                path_str,
+                filename,
+                file_type,
+                path.to_string_lossy().to_string(),
+            );
 
             // Save the block
-            storage::save_block(&block, &data_dir, &mut blocks_cache)?;
+            repo.save(&block)?;
             indexed_blocks.push(block);
         }
     }

--- a/src-tauri/src/commands/workspace.rs
+++ b/src-tauri/src/commands/workspace.rs
@@ -5,7 +5,7 @@ use tauri::State;
 use walkdir::WalkDir;
 
 use crate::error::{AppError, Result};
-use crate::models::{AppState, Block};
+use crate::models::{AppState, Block, BlockKind};
 use crate::repository::{BlockRepository, FileBlockRepository};
 use crate::storage;
 
@@ -25,12 +25,11 @@ pub fn select_workspace(path: String, state: State<AppState>) -> Result<()> {
     let blocks_dir = data_dir.join("blocks");
     let highest_id = storage::find_highest_block_id(&blocks_dir);
     let blocks_cache = storage::load_blocks_cache(&blocks_dir);
-    let mut repository = FileBlockRepository::new(data_dir.clone(), blocks_cache);
+    let repository = FileBlockRepository::new(data_dir.clone(), blocks_cache);
 
     // Update state
     let all_blocks = repository.all()?;
-    *state.blocks_cache.lock().unwrap() =
-        all_blocks.iter().cloned().map(|b| (b.id, b)).collect();
+    *state.blocks_cache.lock().unwrap() = all_blocks.iter().cloned().map(|b| (b.id, b)).collect();
     *state.repository.lock().unwrap() = Some(repository);
     state.next_id.store(highest_id + 1, Ordering::SeqCst);
 

--- a/src-tauri/src/error.rs
+++ b/src-tauri/src/error.rs
@@ -1,0 +1,20 @@
+use serde::Serialize;
+use thiserror::Error;
+
+#[derive(Debug, Error, Serialize)]
+pub enum AppError {
+    #[error("No workspace selected")] 
+    NoWorkspaceSelected,
+    #[error("Block {0} not found")]
+    BlockNotFound(u64),
+    #[error("Block {0} is not a channel")]
+    NotAChannel(u64),
+    #[error(transparent)]
+    Io(#[from] std::io::Error),
+    #[error(transparent)]
+    SerdeJson(#[from] serde_json::Error),
+    #[error(transparent)]
+    Other(#[from] anyhow::Error),
+}
+
+pub type Result<T> = std::result::Result<T, AppError>;

--- a/src-tauri/src/error.rs
+++ b/src-tauri/src/error.rs
@@ -1,9 +1,10 @@
+use serde::ser::Serializer;
 use serde::Serialize;
 use thiserror::Error;
 
-#[derive(Debug, Error, Serialize)]
+#[derive(Debug, Error)]
 pub enum AppError {
-    #[error("No workspace selected")] 
+    #[error("No workspace selected")]
     NoWorkspaceSelected,
     #[error("Block {0} not found")]
     BlockNotFound(u64),
@@ -15,6 +16,15 @@ pub enum AppError {
     SerdeJson(#[from] serde_json::Error),
     #[error(transparent)]
     Other(#[from] anyhow::Error),
+}
+
+impl Serialize for AppError {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(&self.to_string())
+    }
 }
 
 pub type Result<T> = std::result::Result<T, AppError>;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -3,7 +3,9 @@ use tauri::Manager;
 
 mod commands;
 mod models;
+mod repository;
 mod storage;
+mod error;
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {

--- a/src-tauri/src/models.rs
+++ b/src-tauri/src/models.rs
@@ -5,15 +5,94 @@ use std::path::PathBuf;
 use std::sync::atomic::AtomicU64;
 use std::sync::Mutex;
 
-// Block structure with simplified types
+use crate::repository::FileBlockRepository;
+
+use crate::error::AppError;
+
+#[derive(Serialize, Deserialize, Clone, Debug)]
+pub struct ChannelContent {
+    pub title: String,
+    pub description: String,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug)]
+pub struct FileContent {
+    pub path: String,
+    pub filename: String,
+    pub file_type: String,
+    pub full_path: String,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug)]
+#[serde(tag = "type", content = "data")]
+pub enum BlockKind {
+    Channel(ChannelContent),
+    File(FileContent),
+}
+
+impl BlockKind {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            BlockKind::Channel(_) => "channel",
+            BlockKind::File(_) => "file",
+        }
+    }
+}
+
+impl ChannelContent {
+    pub fn new(title: String, description: String) -> Self {
+        Self { title, description }
+    }
+}
+
+impl FileContent {
+    pub fn new(path: String, filename: String, file_type: String, full_path: String) -> Self {
+        Self {
+            path,
+            filename,
+            file_type,
+            full_path,
+        }
+    }
+}
+
 #[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct Block {
     pub id: u64,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
-    pub block_type: String,         // "channel" or "file"
-    pub content: serde_json::Value, // Flexible content structure based on type
-    pub connections: Vec<u64>,      // IDs of blocks connected to this one
+    pub kind: BlockKind,
+    pub connections: Vec<u64>,
+}
+
+impl Block {
+    pub fn new_channel(id: u64, title: String, description: String) -> Self {
+        let now = Utc::now();
+        Block {
+            id,
+            created_at: now,
+            updated_at: now,
+            kind: BlockKind::Channel(ChannelContent::new(title, description)),
+            connections: Vec::new(),
+        }
+    }
+
+    pub fn new_file(
+        id: u64,
+        path: String,
+        filename: String,
+        file_type: String,
+        full_path: String,
+    ) -> Self {
+        let now = Utc::now();
+        Block {
+            id,
+            created_at: now,
+            updated_at: now,
+            kind: BlockKind::File(FileContent::new(path, filename, file_type, full_path)),
+            connections: Vec::new(),
+        }
+    }
 }
 
 // App state
@@ -22,6 +101,7 @@ pub struct AppState {
     pub data_dir: Mutex<Option<PathBuf>>,
     pub next_id: AtomicU64,
     pub blocks_cache: Mutex<HashMap<u64, Block>>,
+    pub repository: Mutex<Option<FileBlockRepository>>,
 }
 
 impl AppState {
@@ -31,6 +111,7 @@ impl AppState {
             data_dir: Mutex::new(None),
             next_id: AtomicU64::new(1),
             blocks_cache: Mutex::new(HashMap::new()),
+            repository: Mutex::new(None),
         }
     }
 }

--- a/src-tauri/src/models.rs
+++ b/src-tauri/src/models.rs
@@ -7,8 +7,6 @@ use std::sync::Mutex;
 
 use crate::repository::FileBlockRepository;
 
-use crate::error::AppError;
-
 #[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct ChannelContent {
     pub title: String,

--- a/src-tauri/src/repository.rs
+++ b/src-tauri/src/repository.rs
@@ -1,0 +1,83 @@
+use std::collections::HashMap;
+use std::fs;
+use std::path::PathBuf;
+
+use crate::error::{AppError, Result};
+use crate::models::{Block, BlockKind};
+use crate::storage;
+
+pub trait BlockRepository {
+    fn all(&self) -> Result<Vec<Block>>;
+    fn all_files(&self) -> Result<Vec<Block>>;
+    fn all_channels(&self) -> Result<Vec<Block>>;
+    fn get(&self, id: u64) -> Result<Block>;
+    fn save(&mut self, block: &Block) -> Result<()>;
+    fn delete(&mut self, id: u64) -> Result<()>;
+}
+
+pub struct FileBlockRepository {
+    data_dir: PathBuf,
+    cache: HashMap<u64, Block>,
+}
+
+impl FileBlockRepository {
+    pub fn new(data_dir: PathBuf, cache: HashMap<u64, Block>) -> Self {
+        Self { data_dir, cache }
+    }
+
+    fn blocks_dir(&self) -> PathBuf {
+        self.data_dir.join("blocks")
+    }
+}
+
+impl BlockRepository for FileBlockRepository {
+    fn all(&self) -> Result<Vec<Block>> {
+        Ok(self.cache.values().cloned().collect())
+    }
+
+    fn all_files(&self) -> Result<Vec<Block>> {
+        Ok(
+            self
+                .cache
+                .values()
+                .filter(|b| matches!(b.kind, BlockKind::File(_)))
+                .cloned()
+                .collect(),
+        )
+    }
+
+    fn all_channels(&self) -> Result<Vec<Block>> {
+        Ok(
+            self
+                .cache
+                .values()
+                .filter(|b| matches!(b.kind, BlockKind::Channel(_)))
+                .cloned()
+                .collect(),
+        )
+    }
+
+    fn get(&self, id: u64) -> Result<Block> {
+        self
+            .cache
+            .get(&id)
+            .cloned()
+            .ok_or(AppError::BlockNotFound(id))
+    }
+
+    fn save(&mut self, block: &Block) -> Result<()> {
+        storage::save_block(block, &self.data_dir, &mut self.cache)
+    }
+
+    fn delete(&mut self, id: u64) -> Result<()> {
+        if !self.cache.contains_key(&id) {
+            return Err(AppError::BlockNotFound(id));
+        }
+        let path = self.blocks_dir().join(format!("{}.json", id));
+        if path.exists() {
+            fs::remove_file(path)?;
+        }
+        self.cache.remove(&id);
+        Ok(())
+    }
+}

--- a/src-tauri/src/storage.rs
+++ b/src-tauri/src/storage.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 use std::fs;
 use std::path::Path;
 
-use crate::error::{AppError, Result};
+use crate::error::Result;
 use crate::models::Block;
 
 // Initialize application directories
@@ -73,11 +73,7 @@ pub fn load_blocks_cache(blocks_dir: &Path) -> HashMap<u64, Block> {
 }
 
 // Save a block to disk and update cache
-pub fn save_block(
-    block: &Block,
-    data_dir: &Path,
-    cache: &mut HashMap<u64, Block>,
-) -> Result<()> {
+pub fn save_block(block: &Block, data_dir: &Path, cache: &mut HashMap<u64, Block>) -> Result<()> {
     let block_path = data_dir.join("blocks").join(format!("{}.json", block.id));
     let json = serde_json::to_string_pretty(&block)?;
     fs::write(block_path, json)?;

--- a/src-tauri/src/storage.rs
+++ b/src-tauri/src/storage.rs
@@ -2,10 +2,11 @@ use std::collections::HashMap;
 use std::fs;
 use std::path::Path;
 
+use crate::error::{AppError, Result};
 use crate::models::Block;
 
 // Initialize application directories
-pub fn initialize_dirs(base_dir: &Path) -> Result<(), Box<dyn std::error::Error>> {
+pub fn initialize_dirs(base_dir: &Path) -> Result<()> {
     let dirs = [base_dir, &base_dir.join("blocks")];
 
     for dir in dirs.iter() {
@@ -76,10 +77,10 @@ pub fn save_block(
     block: &Block,
     data_dir: &Path,
     cache: &mut HashMap<u64, Block>,
-) -> Result<(), String> {
+) -> Result<()> {
     let block_path = data_dir.join("blocks").join(format!("{}.json", block.id));
-    let json = serde_json::to_string_pretty(&block).map_err(|e| e.to_string())?;
-    fs::write(block_path, json).map_err(|e| e.to_string())?;
+    let json = serde_json::to_string_pretty(&block)?;
+    fs::write(block_path, json)?;
 
     // Update cache
     cache.insert(block.id, block.clone());

--- a/src/components/ChannelView.tsx
+++ b/src/components/ChannelView.tsx
@@ -12,6 +12,7 @@ import {
 } from "lucide-react";
 import { useTauri } from "../context/TauriContext";
 import { Block } from "../types";
+import { ChannelService, TauriChannelRepository } from "../services/channelService";
 import { format } from "date-fns";
 
 // We'll use this variable to access the Tauri shell API
@@ -28,14 +29,14 @@ const ChannelView: React.FC<ChannelViewProps> = ({
 }) => {
   const {
     isReady,
-    getBlock,
-    getBlocksInChannel,
     getAllFiles,
     connectBlocks,
     disconnectBlocks,
     updateBlockContent,
     deleteBlock,
   } = useTauri();
+
+  const channelService = new ChannelService(new TauriChannelRepository());
 
   const [channel, setChannel] = useState<Block | null>(null);
   const [blocks, setBlocks] = useState<Block[]>([]);
@@ -74,13 +75,13 @@ const ChannelView: React.FC<ChannelViewProps> = ({
 
     try {
       // Load channel data
-      const channelData = await getBlock(channelId);
+      const channelData = await channelService.get(channelId);
       setChannel(channelData);
       setEditedTitle(channelData.content.title || "");
       setEditedDescription(channelData.content.description || "");
 
       // Load blocks in this channel
-      const channelBlocks = await getBlocksInChannel(channelId);
+      const channelBlocks = await channelService.blocks(channelId);
       setBlocks(channelBlocks);
     } catch (err) {
       console.error("Failed to load channel:", err);

--- a/src/components/MainLayout.tsx
+++ b/src/components/MainLayout.tsx
@@ -153,7 +153,6 @@ const MainLayout: React.FC<MainLayoutProps> = ({ initialFiles }) => {
   };
 
   const handleBlockClick = (blockId: number) => {
-    console.log("Block clicked:", blockId);
     const clickedBlock = blocks.find((block) => block.id === blockId);
     if (clickedBlock && clickedBlock.block_type === "channel") {
       setSelectedChannelId(blockId);

--- a/src/context/TauriContext.tsx
+++ b/src/context/TauriContext.tsx
@@ -39,16 +39,13 @@ export const TauriProvider: React.FC<{ children: React.ReactNode }> = ({
       try {
         // Dynamically import Tauri APIs to ensure they're loaded only in the browser
         if (typeof window !== "undefined") {
-          console.log("Hello");
           // Check if Tauri is available
           if (window.__TAURI__) {
-            console.log("Hello");
             // Access invoke directly
             tauriInvoke = window.__TAURI__.core.invoke;
 
             tauriDialog = window.__TAURI__.dialog;
 
-            console.log("Dialog");
             setIsReady(true);
 
             // Check workspace status after Tauri is ready

--- a/src/services/channelService.ts
+++ b/src/services/channelService.ts
@@ -1,0 +1,46 @@
+export interface ChannelRepository {
+  getAll(): Promise<Block[]>;
+  create(title: string, description: string): Promise<Block>;
+  get(id: number): Promise<Block>;
+  blocks(id: number): Promise<Block[]>;
+}
+
+import { Block } from "../types";
+
+export class TauriChannelRepository implements ChannelRepository {
+  async getAll(): Promise<Block[]> {
+    return window.__TAURI__.core.invoke("get_all_channels");
+  }
+
+  async create(title: string, description: string): Promise<Block> {
+    return window.__TAURI__.core.invoke("create_channel", { title, description });
+  }
+
+  async get(id: number): Promise<Block> {
+    return window.__TAURI__.core.invoke("get_block", { blockId: id });
+  }
+
+  async blocks(id: number): Promise<Block[]> {
+    return window.__TAURI__.core.invoke("get_blocks_in_channel", { channelId: id });
+  }
+}
+
+export class ChannelService {
+  constructor(private repository: ChannelRepository) {}
+
+  getAll() {
+    return this.repository.getAll();
+  }
+
+  create(title: string, description: string) {
+    return this.repository.create(title, description);
+  }
+
+  get(id: number) {
+    return this.repository.get(id);
+  }
+
+  blocks(id: number) {
+    return this.repository.blocks(id);
+  }
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,12 +1,30 @@
 // Block structure that matches the Rust backend
-export interface Block {
+export interface BaseBlock {
   id: number;
   created_at: string;
   updated_at: string;
-  block_type: string; // "channel" or "file" or potentially other types
-  content: any; // Flexible content structure based on type
-  connections: number[]; // IDs of blocks connected to this one
+  connections: number[];
 }
+
+export interface ChannelBlock extends BaseBlock {
+  block_type: "channel";
+  content: {
+    title: string;
+    description: string;
+  };
+}
+
+export interface FileBlock extends BaseBlock {
+  block_type: "file";
+  content: {
+    path: string;
+    filename: string;
+    file_type: string;
+    full_path: string;
+  };
+}
+
+export type Block = ChannelBlock | FileBlock;
 
 // Type guards for block types
 export function isChannelBlock(block: Block): boolean {
@@ -24,6 +42,6 @@ export type BlockFilter = "all" | "channel" | "file";
 export function isChannel(block: Block): boolean {
   return block.block_type === "channel";
 }
-export function isFiel(block: Block): boolean {
+export function isFile(block: Block): boolean {
   return block.block_type === "file";
 }


### PR DESCRIPTION
## Summary
- clean up debug `console.log` calls
- introduce `ChannelService` and repository interface for channel operations
- add Rust `BlockRepository` trait with a file-backed implementation
- refactor workspace and block commands to use the repository
- define discriminated union `Block` types for stronger typing

## Testing
- `cargo fmt --all` *(fails: `cargo-fmt` not installed)*
- `cargo check --manifest-path src-tauri/Cargo.toml` *(fails to fetch crates)*
- `npm test --silent` *(no output)*